### PR TITLE
<Bugfix> Add description's parent slug as viable entry point

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -8,6 +8,7 @@
     "downloads",
     "tabs",
     "scripting",
+    "https://leetcode.com/problems/*",
     "https://leetcode.com/problems/*/description/*"
   ],
 
@@ -19,6 +20,9 @@
     "default_icon": "src/images/icon-48.png",
     "default_title": "LeetCode Description Extractor",
     "default_popup": "src/popup/popup.html",
-    "show_matches": ["https://leetcode.com/problems/*/description/*"]
+    "show_matches": [
+      "https://leetcode.com/problems/*",
+      "https://leetcode.com/problems/*/description/*"
+    ]
   }
 }

--- a/src/content-scripts/verify-url.js
+++ b/src/content-scripts/verify-url.js
@@ -1,0 +1,8 @@
+try {
+    var http = new XMLHttpRequest();
+    http.open('HEAD', document.URL, false);
+    http.send();
+    http.status === 200;
+} catch (_) {
+    false;
+}

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -11,6 +11,14 @@
             .highlight-orange {
                 color: orange;
             }
+
+            #lcde-result {
+                padding: 1em;
+            }
+
+            #lcde-result:empty {
+                display: none;
+            }
         </style>
     </head>
     <body>
@@ -18,7 +26,7 @@
             <h2>
                 L<span class="highlight-orange">C</span>D<span class="highlight-orange">E</span>
             </h2>
-            <button id="lcde-button">Extract Problem</button>
+            <button id="lcde-button" disabled>Extract Problem</button>
             <div id="lcde-result"></div>
         </div>
     </body>

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -1,19 +1,31 @@
 'use strict';
 
-const lcdeButton = document.getElementById('lcde-button');
-lcdeButton.addEventListener('click', () => {
-    onClick();
+document.addEventListener('DOMContentLoaded', async () => {
+    const [tab] = await browser.tabs.query({ active: true, currentWindow: true });
+    const lcdeButton = document.getElementById('lcde-button');
+    const urlCheck = await browser.scripting.executeScript({
+        target: { tabId: tab.id },
+        files: ['../content-scripts/verify-url.js'],
+    });
 
-    setTimeout(function () {
-        window.close();
-    }, 100);
+    const problemAvailable = urlCheck[0]?.result;
+    if (problemAvailable) {
+        lcdeButton.disabled = false;
+        lcdeButton.addEventListener('click', async () => {
+            onClick(tab.id);
+            setTimeout(function () {
+                window.close();
+            }, 100);
+        });
+    } else {
+        const resultEl = document.getElementById('lcde-result');
+        resultEl.textContent = 'Problem description unavailable';
+    }
 });
 
-async function onClick() {
-    const [tab] = await browser.tabs.query({ active: true, currentWindow: true });
-
-    const results = await browser.scripting.executeScript({
-        target: { tabId: tab.id },
+async function onClick(tabId) {
+    await browser.scripting.executeScript({
+        target: { tabId },
         func: extractProblem,
     });
 }


### PR DESCRIPTION
Expand the extension's availability to allow the occasional problem viewing on the slug `/problems/<problem-title>/` as opposed to only `/problems/<problem-title>/description/`

- create simple 200 OK verification script
- make button disabled by default, allow for message to be displayed
- ensure extension only works on valid pages